### PR TITLE
Make nginx/hls container more configurable

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -3,6 +3,9 @@ MAINTAINER  Michael B. Klein <michael.klein@northwestern.edu>
 RUN         apt-get update && apt-get upgrade -y
 RUN         apt-get install -y mediainfo ffmpeg x264 
 RUN         apt-get install -y build-essential git libpcre3-dev zlib1g-dev libssl-dev dnsmasq
+# gettext-base provides 'envsubst', used by nginx.sh
+RUN         apt-get install -y gettext-base
+
 RUN         apt-get clean
 
 ADD         build-nginx.sh /usr/src/build-nginx.sh
@@ -15,8 +18,10 @@ RUN         useradd nginx
 RUN         mkdir /data
 RUN         mkdir -p /var/log/nginx && chown nginx /var/log/nginx
 ADD         stat.xsl  /etc/nginx/stat.xsl
-RUN         mkdir /etc/service/nginx
-RUN         ln -s /usr/local/nginx/sbin/nginx /etc/service/nginx/run
-ADD         nginx.conf /etc/nginx/nginx.conf
+
+ADD         nginx.conf.template /etc/nginx/nginx.conf.template
 RUN         mkdir /etc/service/dnsmasq
 ADD         dnsmasq.sh /etc/service/dnsmasq/run
+RUN         mkdir /etc/service/nginx
+ADD         nginx.sh /etc/service/nginx/run
+RUN         chmod +x /etc/service/nginx/run

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -13,14 +13,14 @@ rtmp {
 
     application avalon {
       play /data;
-      on_play http://avalon/authorize.txt;
+      on_play $AVALON_DOMAIN/authorize.txt;
     }
   }
 }
   
 http {
   server {
-    listen 80;
+    listen $AVALON_STREAMING_PORT;
 
     # This URL provides RTMP statistics in XML
     location /stat {
@@ -55,11 +55,6 @@ http {
 #      autoindex on;
 #    }
     
-    location /thumb/ {
-      alias /data/;
-      vod thumb;
-    }
-    
     location ~ ^/avalon/(?<stream>.+)/(?<resource>.+\.(?:m3u8|ts)) {
       alias /data/$stream;
       vod hls;
@@ -81,7 +76,7 @@ http {
 
     location = /auth {
       resolver 127.0.0.1;
-      proxy_pass http://avalon/authorize.txt?token=$token&name=$stream;
+      proxy_pass $AVALON_DOMAIN/authorize.txt?token=$token&name=$stream;
       proxy_pass_request_body off;
       proxy_set_header Content-Length "";
       proxy_set_header X-Original-URI $request_uri;

--- a/nginx/nginx.sh
+++ b/nginx/nginx.sh
@@ -1,2 +1,10 @@
 #!/bin/sh
-nginx
+
+# Make config file from template
+[ -z "$AVALON_DOMAIN" ] && AVALON_DOMAIN="http://avalon"
+[ -z "$AVALON_STREAMING_PORT" ] && AVALON_STREAMING_PORT=80
+export AVALON_DOMAIN
+export AVALON_STREAMING_PORT
+envsubst '$AVALON_DOMAIN,$AVALON_STREAMING_PORT' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
+
+exec /usr/local/nginx/sbin/nginx


### PR DESCRIPTION
Allow the following environment variables to override the nginx configuration:

* `AVALON_DOMAIN` (default `http://avalon`)
* `AVALON_STREAMING_PORT` (default `80`)

An example of usage is here (lightweight avalon, where webserver runs on localhost):

https://github.com/ualbertalib/avalon/blob/cwant/avalon-6-docker-tweaks/docker-compose.lightweight.yml#L55-L58

Also: removed the `thumb` section (nginx chokes on it)
