### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - FEDORA_DB_PASSWORD
       - PGDATA=/data
       - POSTGRES_USER=postgres
+      - POSTGRES_HOST_AUTH_METHOD=trust
   fedora:
     image: avalonmediasystem/fedora:4.7.5
     build:


### PR DESCRIPTION
Latest postgres containers require a password or a host trust, so adding a trust to avoid the db container dying off with a 'no password' error.