### PR TITLE
Bug Fix: MODESHAPE_CONFIG is required

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
         awslogs-group: "${FEDORA_LOGGROUP}"
         awslogs-create-group: "true"
     environment:
+      - MODESHAPE_CONFIG=${FEDORA_MODESHAPE_CONFIG}
       - JAVA_OPTIONS=${FEDORA_OPTIONS}
     volumes:
       - fedora:/data


### PR DESCRIPTION
Hello,

I've figured out the issue Emory was having, it relates to Phuong and I removing the MODESHAPE_CONFIG variable a few PRs ago. Apparently if that variable is not supplied it defaults to config/file-simple/repository.json, the D flag with fcrepo.modeshape.configuration is ignored. 

Phuong you had the right idea checking to see if our PG database existed, but remember we had MODESHAPE_CONFIG hard coded to ssl for awhile, if we had examined that DB closely we would have seen it hadn't been written to in months.

I will make another PR in avalon-terraform with the D flag removed and a new env variable in the compose.tf file.
