### PR TITLE
Prepends bundle exec to rails s so gems in gemfile can be used

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,7 +90,7 @@ services:
     restart: always
   avalon: &avalon
     image: ${AVALON_DOCKER_REPO}:${AVALON_REV:-latest}
-    command: bash -c "rake db:migrate; rails server -b 0.0.0.0"
+    command: bash -c "rake db:migrate; bundle exec rails server -b 0.0.0.0"
     env_file:
       - .env
     logging:


### PR DESCRIPTION
* When deploying with docker-compose and starting rails s, we want to use the gems in our gemfile on startup. By using `bundle exec` we ensure that gems (and gem versions) in our gemfile are used.