### PR TITLE
Ensure that ActiveStorage setting ENV variables pass into the avalon and worker containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,6 +139,8 @@ services:
       - Z3950_DATABASE
       - Z3950_HOST
       - Z3950_PORT
+      - SETTINGS__ACTIVE_STORAGE__SERVICE
+      - SETTINGS__ACTIVE_STORAGE__BUCKET
     healthcheck:
       test: curl --fail -s http://localhost:3000/ || exit 1
       interval: 2m30s


### PR DESCRIPTION
Resolves #77

Avalon-terraform added ENV variables for these two settings in https://github.com/avalonmediasystem/avalon-terraform/pull/37 but the docker-compose.yml in the `aws_min` branch was never updated to pass them along to the avalon container so Avalon was continuing to use default local storage.  This local storage wasn't on a volume so was susceptible to loss on restarts.  Note that if using s3 the supplemental file bucket needs to have CORS enabled (see https://github.com/avalonmediasystem/avalon-terraform/pull/48)