### PR TITLE
Make the "cache" service's Nginx regularly resolve service names.

### DIFF
--- a/cache.conf
+++ b/cache.conf
@@ -6,6 +6,13 @@ server {
   listen 80 default_server;
   client_max_body_size 250M;
 
+  # The IP of a hard-coded server name in a 'proxy_pass' directive is resolved
+  # only when Nginx starts, but the IP (or IPs) of Docker containers may change
+  # when Docker redeploys or scales them. Putting a server's name in a variable
+  # causes Nginx to resolve it dynamically.
+  resolver 127.0.0.11 valid=2s ipv6=off;
+  set $avalon_backend avalon;
+
 #  location ~ /master_files/(?<mfid>.+)/thumbnail {
 #    add_header X-Cached $upstream_cache_status;
 #    proxy_ignore_headers "Set-Cookie";
@@ -13,7 +20,7 @@ server {
 #    proxy_ignore_headers Cache-Control;
 #
 #    proxy_cache thumb_cache;
-#    proxy_pass http://avalon:3000/master_files/$mfid/thumbnail;
+#    proxy_pass http://$avalon_backend:3000/master_files/$mfid/thumbnail;
 #  }
 #
 #  location ~ /master_files/(?<mfid>.+)/poster {
@@ -23,14 +30,14 @@ server {
 #    proxy_ignore_headers Cache-Control;
 #
 #    proxy_cache thumb_cache;
-#    proxy_pass http://avalon:3000/master_files/$mfid/poster;
+#    proxy_pass http://$avalon_backend:3000/master_files/$mfid/poster;
 #  }
 
   location /assets {
     add_header X-Cached $upstream_cache_status;
 
     proxy_cache thumb_cache;
-    proxy_pass http://avalon:3000/assets;
+    proxy_pass http://$avalon_backend:3000/assets;
   }
 
   location /packs {
@@ -38,11 +45,11 @@ server {
     add_header X-Cached $upstream_cache_status;
 
     proxy_cache thumb_cache;
-    proxy_pass http://avalon:3000/packs;
+    proxy_pass http://$avalon_backend:3000/packs;
   }
 
   location / {
-    proxy_pass http://avalon:3000;
+    proxy_pass http://$avalon_backend:3000;
 
     proxy_set_header  Host $host;
     proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Without this, Nginx in the Cache container resolves the IP for the Avalon container when it starts and often fails if the Avalon container is restarted or if the Cache container starts before the Avalon container.