### PR TITLE
cache: Pass correct URL.

### DIFF
--- a/cache.conf
+++ b/cache.conf
@@ -37,7 +37,7 @@ server {
     add_header X-Cached $upstream_cache_status;
 
     proxy_cache thumb_cache;
-    proxy_pass http://$avalon_backend:3000/assets;
+    proxy_pass http://$avalon_backend:3000$uri;
   }
 
   location /packs {
@@ -45,7 +45,7 @@ server {
     add_header X-Cached $upstream_cache_status;
 
     proxy_cache thumb_cache;
-    proxy_pass http://$avalon_backend:3000/packs;
+    proxy_pass http://$avalon_backend:3000$uri;
   }
 
   location / {


### PR DESCRIPTION
I goofed in my last PR (#89): [Nginx doesn't replace](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass:~:text=When%20variables%20are,original%20request%20URI.) proxied URLs when `proxy_pass` is used with a variable, so the original URL needs to be passed explicitly.

I missed my mistake when I tested it because I hadn't realized that restarting the cache container doesn't clear the Nginx cache. XD XD :rabbit: