### PR TITLE
Bump avalon and nginx hls image tags

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
     environment:
       - SOLR_MODULES=analysis-extras,extraction
   hls:
-    image: avalonmediasystem/nginx
+    image: avalonmediasystem/nginx:avalon-8.2
     build:
       context: ./nginx
     environment:
@@ -53,9 +53,9 @@ services:
   redis:
     image: redis:alpine
   avalon: &avalon
-    image: avalonmediasystem/avalon:8
+    image: avalonmediasystem/avalon:8.2
     build:
-      context: https://github.com/avalonmediasystem/avalon.git#v8.1.1
+      context: https://github.com/avalonmediasystem/avalon.git#v8.2.0
       target: prod
     command: bash -c "bundle exec rake db:migrate && bundle exec rails server -b 0.0.0.0"
     depends_on:


### PR DESCRIPTION
Preparing for avalon 8.2 release.  Once avalon 8.2 is tagged and docker image pushed then this can be merged and this repo tagged.