### PR TITLE
Explicitly turn on S3 auth with ENVVAR and fix streaming from S3 when not using auth

### DIFF
--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -41,11 +41,26 @@ http {
     location /s3/avalon/ {
       internal;
 
-      proxy_set_header Authorization              $s3auth;
-      proxy_set_header Host                       $S3_SERVER;
-      proxy_set_header x-amz-date                 $awsDate;
-      # Hardcode hash for empty string since we're only ever doing GET requests
-      proxy_set_header x-amz-content-sha256       "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+      # proxy_set_header skips setting header if value is empty so only set if s3 auth is enabled
+      set $auth_authz '';
+      set $auth_host '';
+      set $auth_date '';
+      set $auth_sha '';
+
+      set $do_s3_auth $S3_AUTH;
+      if ($do_s3_auth) {
+        set $auth_authz $s3auth;
+        set $auth_host $S3_SERVER;
+        set $auth_date $awsDate;
+        # Hardcode hash for empty string since we're only ever doing GET requests
+        set $auth_sha "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+      }
+
+      proxy_set_header Authorization              $auth_authz;
+      proxy_set_header Host                       $auth_host;
+      proxy_set_header x-amz-date                 $auth_date;
+      proxy_set_header x-amz-content-sha256       $auth_sha;
+
       proxy_pass $AVALON_STREAMING_BUCKET_URL;
     }
     

--- a/nginx/nginx.sh
+++ b/nginx/nginx.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Make config file from template
 [ -z "$AVALON_DOMAIN" ] && AVALON_DOMAIN="http://avalon"
@@ -8,12 +8,21 @@
 [ -z "$VOD_MODE" ] && VOD_MODE="remote"
 [ -z "$S3_REGION" ] && S3_REGION="us-east-1"
 [ -z "$S3_SERVER" ] && S3_SERVER="$AVALON_STREAMING_BUCKET.s3.amazonaws.com"
+[ -z "$S3_AUTH" ] && S3_AUTH="false"
+S3_AUTH=`echo "${S3_AUTH}" | tr '[:upper:]' '[:lower:]'`
+if [[ $S3_AUTH == "true" ]]; then
+  S3_AUTH="1"
+else
+  S3_AUTH="0"
+fi
+
 export AVALON_DOMAIN
 export AVALON_STREAMING_PORT
 export AVALON_STREAMING_BUCKET_URL
 export VOD_MODE
 export S3_REGION
 export S3_SERVER
-envsubst '$AVALON_DOMAIN,$AVALON_STREAMING_PORT,$AVALON_STREAMING_BUCKET_URL,$VOD_MODE,$S3_SERVER' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
+export S3_AUTH
+envsubst '$AVALON_DOMAIN,$AVALON_STREAMING_PORT,$AVALON_STREAMING_BUCKET_URL,$VOD_MODE,$S3_SERVER,$S3_AUTH' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
 
 exec /usr/local/nginx/sbin/nginx


### PR DESCRIPTION
Will need a new image built and pushed to the `avalon-8.2` tag.  Then test on dev and demo site.